### PR TITLE
Use Math.floor for time calculations

### DIFF
--- a/src/lib/timeAgo.ts
+++ b/src/lib/timeAgo.ts
@@ -2,10 +2,10 @@
 export default function timeAgo(dateString: string): string {
   const date = new Date(dateString);
   const now = new Date();
-  const seconds = Math.round((now.getTime() - date.getTime()) / 1000);
-  const minutes = Math.round(seconds / 60);
-  const hours = Math.round(minutes / 60);
-  const days = Math.round(hours / 24);
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
 
   if (seconds < 60) return `${seconds} seconds ago`;
   if (minutes < 60) return `${minutes} minutes ago`;


### PR DESCRIPTION
## Summary
- avoid rounding up when computing time intervals in `timeAgo`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 353 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ec8e91c48331a6aa91ef5db2ab5f